### PR TITLE
Auto-capitalize only the first word in page titles, fix #34

### DIFF
--- a/components/PageTitle.vue
+++ b/components/PageTitle.vue
@@ -1,6 +1,6 @@
 <template>
-  <h3 class="page-title-sm xl:page-title capitalize">
-    {{ $t(path) }}
+  <h3 class="page-title-sm xl:page-title">
+    {{ capitalizeFirst($t(path)) }}
   </h3>
 </template>
 
@@ -10,5 +10,9 @@ import { Component, Prop, Vue } from 'nuxt-property-decorator'
 @Component
 export default class PageTitle extends Vue {
   @Prop() path!: string
+
+  capitalizeFirst (sentence: string): string {
+    return sentence.charAt(0).toUpperCase() + sentence.slice(1)
+  }
 }
 </script>


### PR DESCRIPTION
Instead of capitalizing each word we now will only do so for the first letter.

We previously used the `tailwind` *capitalize* class which did not work properly for words separated by dashes as it was
the case for **Implica-Te** which should have been **Implica-te**.

The change introduced here will not bother to capitalize all the words anymore.
This also affects **Apel Pentru Voluntari** which becomes **Apel pentru voluntari**.